### PR TITLE
feat: Implements multi var in the key for the keyval command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ in the key-value database.
 The database is stored in shared memory or Redis as specified
 by the zone parameter.
 
+In `key`, you can use a mix of variables and text or just variables.
+
+For example:
+  - `$remote_addr:$http_user_agent`
+  - `'$remote_addr    $http_user_agent   $host "a random text"'`
+
+<br>
+
 ```
 Syntax: keyval_zone zone=name:size;
 Default: -

--- a/src/ngx_http_keyval_module.c
+++ b/src/ngx_http_keyval_module.c
@@ -143,15 +143,15 @@ ngx_http_keyval_variable_get_key(ngx_http_request_t *r,
     }
 
     for (ngx_int_t i = 0 ; i < var->num_indexes ; i++) { // For each variable, verify the size and store it
-	    v[i] = ngx_http_get_indexed_variable(r, var->key_indexes[i]); // Get the variable
+      v[i] = ngx_http_get_indexed_variable(r, var->key_indexes[i]); // Get the variable
 
-	    if (v[i] == NULL || v[i]-> not_found) { // Sanity check
-		    ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
-				    "keyval: variable specified was not provided");
-		    return NGX_ERROR;
-	    }
+      if (v[i] == NULL || v[i]-> not_found) { // Sanity check
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+            "keyval: variable specified was not provided");
+        return NGX_ERROR;
+      }
 
-	    size_string += v[i]->len; // Increments final string size
+      size_string += v[i]->len; // Increments final string size
     }
 
     /* Variable that holds the final string and it's allocated with the exactly size it needs */
@@ -169,23 +169,23 @@ ngx_http_keyval_variable_get_key(ngx_http_request_t *r,
     u_char *last_space_available = key->data; // The same purpose as size_string var, but for the final string space
 
     for ( ; *(string_var.data) != '\0' ; string_var.data++) { // Walks by the intermediate string
-	    if (*(string_var.data) == '$') { // A variable belongs here. Do the replace in the variable order we stored
-		    last_space_available = ngx_cpystrn(last_space_available, v[current_index]->data, v[current_index]->len + 1); // Replace $ by the content of the variable
-		    key->len += v[current_index++]->len; // Increments string size
-	    }
+      if (*(string_var.data) == '$') { // A variable belongs here. Do the replace in the variable order we stored
+        last_space_available = ngx_cpystrn(last_space_available, v[current_index]->data, v[current_index]->len + 1); // Replace $ by the content of the variable
+        key->len += v[current_index++]->len; // Increments string size
+      }
 
-	    else { // Common char, just copy
-		    *last_space_available = *(string_var.data);
-		    last_space_available += sizeof(u_char); // Increments the pointer by the size of the data type
-		    key->len++;
-	    }
+      else { // Common char, just copy
+        *last_space_available = *(string_var.data);
+        last_space_available += sizeof(u_char); // Increments the pointer by the size of the data type
+        key->len++;
+      }
     }
 
     *last_space_available = '\0'; // Ends the string
   }
 
   else // No vars, just copy
-	  *key = var->key_string;
+    *key = var->key_string;
 
   return NGX_OK;
 }

--- a/src/ngx_http_keyval_module.c
+++ b/src/ngx_http_keyval_module.c
@@ -121,73 +121,10 @@ ngx_http_keyval_conf_set_variable(ngx_conf_t *cf,
   return NGX_CONF_OK;
 }
 
-static ngx_int_t
-ngx_http_keyval_variable_get_key(ngx_http_request_t *r,
-                                 ngx_keyval_variable_t *var, ngx_str_t *key)
+static ngx_variable_value_t *
+ngx_http_keyval_get_indexed_variable(void *data, ngx_uint_t index)
 {
-  if (!key || !var) {
-    return NGX_ERROR;
-  }
-
-  if (var->num_indexes != 0) { // There is at least one variable to replace
-    ngx_http_variable_value_t **v; // Array to store each variable
-    ngx_int_t current_index = 0; // Current variable index we're reading
-    ngx_str_t string_var = var->key_string; // Pointer to doesn't change the original one
-    ngx_uint_t size_string = 0; // Size of the final string with variables replaces and other characters
-
-    v = ngx_palloc(r->connection->pool, sizeof(ngx_http_variable_value_t *) * var->num_indexes);
-
-    if (v == NULL) {
-      ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "keyval: failed to allocate memory for variable values array");
-      return NGX_ERROR;
-    }
-
-    for (ngx_int_t i = 0 ; i < var->num_indexes ; i++) { // For each variable, verify the size and store it
-      v[i] = ngx_http_get_indexed_variable(r, var->key_indexes[i]); // Get the variable
-
-      if (v[i] == NULL || v[i]-> not_found) { // Sanity check
-        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
-            "keyval: variable specified was not provided");
-        return NGX_ERROR;
-      }
-
-      size_string += v[i]->len; // Increments final string size
-    }
-
-    /* Variable that holds the final string and it's allocated with the exactly size it needs */
-
-    key->data = (u_char *) ngx_pnalloc(r->connection->pool, size_string + (string_var.len - var->num_indexes) + 1);
-
-    if (key->data == NULL){
-      ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-          "keyval: error allocating memory for key string");
-      return NGX_ERROR;
-    }
-
-    key->len = 0;
-
-    u_char *last_space_available = key->data; // The same purpose as size_string var, but for the final string space
-
-    for ( ; *(string_var.data) != '\0' ; string_var.data++) { // Walks by the intermediate string
-      if (*(string_var.data) == '$') { // A variable belongs here. Do the replace in the variable order we stored
-        last_space_available = ngx_cpystrn(last_space_available, v[current_index]->data, v[current_index]->len + 1); // Replace $ by the content of the variable
-        key->len += v[current_index++]->len; // Increments string size
-      }
-
-      else { // Common char, just copy
-        *last_space_available = *(string_var.data);
-        last_space_available += sizeof(u_char); // Increments the pointer by the size of the data type
-        key->len++;
-      }
-    }
-
-    *last_space_available = '\0'; // Ends the string
-  }
-
-  else // No vars, just copy
-    *key = var->key_string;
-
-  return NGX_OK;
+  return ngx_http_get_indexed_variable((ngx_http_request_t *) data, index);
 }
 
 static ngx_int_t
@@ -212,7 +149,9 @@ ngx_http_keyval_variable_init(ngx_http_request_t *r, uintptr_t data,
 
   var = (ngx_keyval_variable_t *) data;
 
-  if (ngx_http_keyval_variable_get_key(r, var, key) != NGX_OK) {
+  if (ngx_keyval_variable_get_key(r->connection, var, key,
+                                  ngx_http_keyval_get_indexed_variable,
+                                  (void *) r) != NGX_OK) {
     ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                   "keyval: rejected due to not found variable key");
     return NGX_ERROR;

--- a/src/ngx_http_keyval_module.c
+++ b/src/ngx_http_keyval_module.c
@@ -129,19 +129,16 @@ ngx_http_keyval_variable_get_key(ngx_http_request_t *r,
     return NGX_ERROR;
   }
 
-  if (var->num_indexes != 0) // There is at least one variable to replace
-  {
+  if (var->num_indexes != 0) { // There is at least one variable to replace
     ngx_http_variable_value_t *v[var->num_indexes]; // Array to store each variable
     ngx_int_t current_index = 0; // Current variable index we're reading
     ngx_str_t string_var = var->key_string; // Pointer to doesn't change the original one
     ngx_uint_t size_string = 0; // Size of the final string with variables replaces and other characters
 
-    for (ngx_int_t i = 0 ; i < var->num_indexes ; i++) // For each variable, verify the size and store it
-    {
+    for (ngx_int_t i = 0 ; i < var->num_indexes ; i++) { // For each variable, verify the size and store it
 	    v[i] = ngx_http_get_indexed_variable(r, var->key_indexes[i]); // Get the variable
 
-	    if (v[i] == NULL || v[i]-> not_found) // Sanity check
-	    {
+	    if (v[i] == NULL || v[i]-> not_found) { // Sanity check
 		    ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
 				    "keyval: variable specified was not provided");
 		    return NGX_ERROR;
@@ -153,20 +150,24 @@ ngx_http_keyval_variable_get_key(ngx_http_request_t *r,
     /* Variable that holds the final string and it's allocated with the exactly size it needs */
 
     key->data = (u_char *) ngx_pnalloc(r->pool, size_string + (string_var.len - var->num_indexes) + 1);
+
+    if (key->data == NULL){
+      ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+          "keyval: error allocating memory for key string");
+      return NGX_ERROR;
+    }
+
     key->len = 0;
 
     u_char *last_space_available = key->data; // The same purpose as size_string var, but for the final string space
 
-    for ( ; *(string_var.data) != '\0' ; string_var.data++) // Walks by the intermediate string
-    {
-	    if (*(string_var.data) == '$') // A variable belongs here. Do the replace in the variable order we stored
-	    {
+    for ( ; *(string_var.data) != '\0' ; string_var.data++) { // Walks by the intermediate string
+	    if (*(string_var.data) == '$') { // A variable belongs here. Do the replace in the variable order we stored
 		    last_space_available = ngx_cpystrn(last_space_available, v[current_index]->data, v[current_index]->len + 1); // Replace $ by the content of the variable
 		    key->len += v[current_index++]->len; // Increments string size
 	    }
 
-	    else // Common char, just copy
-	    {
+	    else { // Common char, just copy
 		    *last_space_available = *(string_var.data);
 		    last_space_available += sizeof(u_char); // Increments the pointer by the size of the data type
 		    key->len++;

--- a/src/ngx_keyval.c
+++ b/src/ngx_keyval.c
@@ -534,6 +534,81 @@ ngx_keyval_conf_set_variable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
   return NGX_CONF_OK;
 }
 
+ngx_int_t
+ngx_keyval_variable_get_key(ngx_connection_t *connection,
+                            ngx_keyval_variable_t *var, ngx_str_t *key,
+                            ngx_keyval_get_index_variable get_index_variable,
+                            void *data)
+{
+  if (!key || !var || !connection || !data) {
+    return NGX_ERROR;
+  }
+
+  if (var->num_indexes != 0) {
+    ngx_variable_value_t **v;
+    ngx_int_t current_index = 0;
+    ngx_str_t string_var = var->key_string;
+    ngx_uint_t size_string = 0;
+    u_char *last_space_available;
+
+    v = ngx_palloc(connection->pool,
+                   sizeof(ngx_variable_value_t *) * var->num_indexes);
+
+    if (v == NULL) {
+      ngx_log_error(NGX_LOG_ERR, connection->log, 0,
+                    "keyval: failed to allocate memory "
+                    "for variable values array");
+      return NGX_ERROR;
+    }
+
+    for (ngx_int_t i = 0 ; i < var->num_indexes ; i++) {
+      v[i] = get_index_variable(data, var->key_indexes[i]);
+
+      if (v[i] == NULL || v[i]-> not_found) {
+        ngx_log_error(NGX_LOG_INFO, connection->log, 0,
+                      "keyval: variable specified was not provided");
+        return NGX_ERROR;
+      }
+
+      size_string += v[i]->len;
+    }
+
+    key->data = (u_char *) ngx_pnalloc(connection->pool,
+                                       size_string
+                                       + (string_var.len - var->num_indexes)
+                                       + 1);
+
+    if (key->data == NULL) {
+      ngx_log_error(NGX_LOG_ERR, connection->log, 0,
+                    "keyval: error allocating memory for key string");
+      return NGX_ERROR;
+    }
+
+    key->len = 0;
+
+    last_space_available = key->data;
+
+    for ( ; *(string_var.data) != '\0' ; string_var.data++) {
+      if (*(string_var.data) == '$') {
+        last_space_available = ngx_cpystrn(last_space_available,
+                                           v[current_index]->data,
+                                           v[current_index]->len + 1);
+        key->len += v[current_index++]->len;
+      } else {
+        *last_space_available = *(string_var.data);
+        last_space_available += sizeof(u_char);
+        key->len++;
+      }
+    }
+
+    *last_space_available = '\0';
+  } else {
+    *key = var->key_string;
+  }
+
+  return NGX_OK;
+}
+
 void *
 ngx_keyval_create_main_conf(ngx_conf_t *cf)
 {

--- a/src/ngx_keyval.c
+++ b/src/ngx_keyval.c
@@ -460,7 +460,7 @@ ngx_keyval_conf_set_variable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
   (*var)->key_string.data = ngx_pnalloc(cf->pool, SIZE_BUFFER_INTERMEDIATE_STRING); // Allocates space for intermediate string
 
   if ( (*var)->key_string.data == NULL)
-	  return "failed to allocate memory for intermediate string";
+    return "failed to allocate memory for intermediate string";
 
   u_char *variable_name = ngx_alloc(SIZE_BUFFER_VARIABLE_NAME, cf->log); // Buffer for var name
 
@@ -482,8 +482,7 @@ ngx_keyval_conf_set_variable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
       int variable_name_str_index = 0; // Index of the string that holds the name of the var we're reading
 
       while ((*string != ' ' && *string != ':' && *string != '"' &&
-          *string != '\'' && *string != '\\') && *string != '\0') // Take var chars until string end or see a delimiter
-      {
+          *string != '\'' && *string != '\\') && *string != '\0') { // Take var chars until string end or see a delimiter
         variable_name[variable_name_str_index] = *string;
         variable_name_str_index++;
         string++;
@@ -505,13 +504,13 @@ ngx_keyval_conf_set_variable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
   }
 
   if (num_vars == 0) { // There's no var on the string, just copies the format string
-	  (*var)->num_indexes = 0;
-	  (*var)->key_string = value[1];
+    (*var)->num_indexes = 0;
+    (*var)->key_string = value[1];
   }
 
   else {
-	  (*var)->key_string.data[final_pos] = '\0'; // Marks the end of the string
-	  (*var)->num_indexes = num_vars; // Saves the number of vars
+    (*var)->key_string.data[final_pos] = '\0'; // Marks the end of the string
+    (*var)->num_indexes = num_vars; // Saves the number of vars
   }
 
   ngx_free(variable_name);

--- a/src/ngx_keyval.c
+++ b/src/ngx_keyval.c
@@ -413,12 +413,17 @@ ngx_keyval_conf_set_variable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
                              ngx_keyval_get_variable_index get_variable_index)
 {
   ngx_str_t *value;
+  int final_pos = 0; // Current index of the intermediate string
+  int num_vars = 0; // Counts the number of vars (limited by 15)
 
   if (!config || !tag) {
     return "missing required parameter";
   }
 
   value = cf->args->elts;
+
+  const int SIZE_BUFFER_VARIABLE_NAME = value[1].len, SIZE_BUFFER_INTERMEDIATE_STRING = value[1].len; // Sizes for buffers
+  const int MAX_NUM_VAR = 15; // Max vars allowed
 
   if (value[1].len == 0) {
     return "is empty";
@@ -452,62 +457,64 @@ ngx_keyval_conf_set_variable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
   u_char *string = value[1].data; // Different pointer to not affect the original
 
   (*var)->key_string.len = 0;
-  (*var)->key_string.data = ngx_pnalloc(cf->pool, 10000); // Allocates space for intermediate string
+  (*var)->key_string.data = ngx_pnalloc(cf->pool, SIZE_BUFFER_INTERMEDIATE_STRING); // Allocates space for intermediate string
 
   if ( (*var)->key_string.data == NULL)
 	  return "failed to allocate memory for intermediate string";
 
-  int final_pos = 0; // Current index of the intermediate string
-  int count = 0; // Counts the number of vars (limited by 15)
+  u_char *variable_name = ngx_alloc(SIZE_BUFFER_VARIABLE_NAME, cf->log); // Buffer for var name
 
-  while (*string != '\0')
-  {
-    if (*string == '$') // At least one var present
-    {
+  if (variable_name == NULL)
+    return "failed to allocate memory for variable name buffer";
+
+  while (*string != '\0') {
+    if (num_vars == MAX_NUM_VAR) { // Max of 15 vars reached
+
+      ngx_free(variable_name);
+      return "max variables reached";
+    }
+
+    if (*string == '$') { // At least one var present
       (*var)->key_string.data[final_pos++] = '$';
       (*var)->key_string.len++;
       string++;
 
-      int c = 0; // Index of the string that holds the name of the var we're reading
-
-      u_char aux[512] = {'\0'}; // Buffer for var name
+      int variable_name_str_index = 0; // Index of the string that holds the name of the var we're reading
 
       while ((*string != ' ' && *string != ':' && *string != '"' &&
           *string != '\'' && *string != '\\') && *string != '\0') // Take var chars until string end or see a delimiter
       {
-        aux[c] = *string;
-        c++;
+        variable_name[variable_name_str_index] = *string;
+        variable_name_str_index++;
         string++;
       }
 
-      ngx_str_t str = ngx_string(aux); // Converts normal string to ngx_str_t
-      str.len = ngx_strlen(aux); // By Nginx doc, str.len is the sizeof of the buffer, which is 512. We take the length by strlen
-      (*var)->key_indexes[count] = get_variable_index(cf, &str); // Saves the index of the variable from nginx memory
-      count++; // One more var read
+      variable_name[variable_name_str_index] = '\0';
+
+      ngx_str_t str = ngx_string(variable_name); // Converts normal string to ngx_str_t
+      str.len = ngx_strlen(variable_name); // By Nginx doc, str.len is the sizeof of the buffer or pointer. We take the length by strlen to get correct result
+      (*var)->key_indexes[num_vars] = get_variable_index(cf, &str); // Saves the index of the variable from nginx memory
+      num_vars++; // One more var read
     }
 
-    else // Normal char, read and proceed
-    {
+    else { // Normal char, read and proceed
       (*var)->key_string.len++;
       (*var)->key_string.data[final_pos++] = *string;
       string++;
     }
-
-    if (count == 15) // Max of 15 vars allowed
-      return "max variables reached";
   }
 
-  if (count == 0) // There's no var on the string, just copies the format string
-  {
+  if (num_vars == 0) { // There's no var on the string, just copies the format string
 	  (*var)->num_indexes = 0;
 	  (*var)->key_string = value[1];
   }
 
-  else
-  {
+  else {
 	  (*var)->key_string.data[final_pos] = '\0'; // Marks the end of the string
-	  (*var)->num_indexes = count; // Saves the number of vars
+	  (*var)->num_indexes = num_vars; // Saves the number of vars
   }
+
+  ngx_free(variable_name);
 
   (*var)->variable = value[2];
 

--- a/src/ngx_keyval.c
+++ b/src/ngx_keyval.c
@@ -423,7 +423,6 @@ ngx_keyval_conf_set_variable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
   value = cf->args->elts;
 
   const int SIZE_BUFFER_VARIABLE_NAME = value[1].len, SIZE_BUFFER_INTERMEDIATE_STRING = value[1].len; // Sizes for buffers
-  const int MAX_NUM_VAR = 15; // Max vars allowed
 
   if (value[1].len == 0) {
     return "is empty";
@@ -454,6 +453,21 @@ ngx_keyval_conf_set_variable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
     return "failed to allocate iteam";
   }
 
+  if (config->indexes == NULL) {
+    config->indexes = ngx_array_create(cf->pool, 4, sizeof(ngx_array_t));
+    if (config->indexes == NULL) {
+      return "failed to allocate";
+    }
+  }
+  (*var)->indexes = ngx_array_push(config->indexes);
+  if ((*var)->indexes == NULL) {
+    return "failed to allocate iteam";
+  }
+  (*var)->indexes = ngx_array_create(cf->pool, 4, sizeof(ngx_int_t));
+  if ((*var)->indexes == NULL) {
+    return "failed to allocate";
+  }
+
   u_char *string = value[1].data; // Different pointer to not affect the original
 
   (*var)->key_string.len = 0;
@@ -468,12 +482,6 @@ ngx_keyval_conf_set_variable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
     return "failed to allocate memory for variable name buffer";
 
   while (*string != '\0') {
-    if (num_vars == MAX_NUM_VAR) { // Max of 15 vars reached
-
-      ngx_free(variable_name);
-      return "max variables reached";
-    }
-
     if (*string == '$') { // At least one var present
       (*var)->key_string.data[final_pos++] = '$';
       (*var)->key_string.len++;
@@ -492,7 +500,13 @@ ngx_keyval_conf_set_variable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
 
       ngx_str_t str = ngx_string(variable_name); // Converts normal string to ngx_str_t
       str.len = ngx_strlen(variable_name); // By Nginx doc, str.len is the sizeof of the buffer or pointer. We take the length by strlen to get correct result
-      (*var)->key_indexes[num_vars] = get_variable_index(cf, &str); // Saves the index of the variable from nginx memory
+
+      ngx_int_t *index = ngx_array_push((*var)->indexes);
+      if (index == NULL) {
+        return "failed to allocate item";
+      }
+      *index = get_variable_index(cf, &str);
+
       num_vars++; // One more var read
     }
 
@@ -504,13 +518,11 @@ ngx_keyval_conf_set_variable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
   }
 
   if (num_vars == 0) { // There's no var on the string, just copies the format string
-    (*var)->num_indexes = 0;
     (*var)->key_string = value[1];
   }
 
   else {
     (*var)->key_string.data[final_pos] = '\0'; // Marks the end of the string
-    (*var)->num_indexes = num_vars; // Saves the number of vars
   }
 
   ngx_free(variable_name);
@@ -544,7 +556,7 @@ ngx_keyval_variable_get_key(ngx_connection_t *connection,
     return NGX_ERROR;
   }
 
-  if (var->num_indexes != 0) {
+  if (var->indexes->nelts != 0) {
     ngx_variable_value_t **v;
     ngx_int_t current_index = 0;
     ngx_str_t string_var = var->key_string;
@@ -552,7 +564,7 @@ ngx_keyval_variable_get_key(ngx_connection_t *connection,
     u_char *last_space_available;
 
     v = ngx_palloc(connection->pool,
-                   sizeof(ngx_variable_value_t *) * var->num_indexes);
+                   sizeof(ngx_variable_value_t *) * var->indexes->nelts);
 
     if (v == NULL) {
       ngx_log_error(NGX_LOG_ERR, connection->log, 0,
@@ -561,8 +573,10 @@ ngx_keyval_variable_get_key(ngx_connection_t *connection,
       return NGX_ERROR;
     }
 
-    for (ngx_int_t i = 0 ; i < var->num_indexes ; i++) {
-      v[i] = get_index_variable(data, var->key_indexes[i]);
+    ngx_int_t *indexes = var->indexes->elts;
+
+    for (ngx_uint_t i = 0 ; i < var->indexes->nelts ; i++) {
+      v[i] = get_index_variable(data, indexes[i]);
 
       if (v[i] == NULL || v[i]-> not_found) {
         ngx_log_error(NGX_LOG_INFO, connection->log, 0,
@@ -575,7 +589,7 @@ ngx_keyval_variable_get_key(ngx_connection_t *connection,
 
     key->data = (u_char *) ngx_pnalloc(connection->pool,
                                        size_string
-                                       + (string_var.len - var->num_indexes)
+                                       + (string_var.len - var->indexes->nelts)
                                        + 1);
 
     if (key->data == NULL) {

--- a/src/ngx_keyval.h
+++ b/src/ngx_keyval.h
@@ -64,12 +64,14 @@ typedef struct {
 #endif
 
 typedef ngx_int_t (*ngx_keyval_get_variable_index)(ngx_conf_t *cf, ngx_str_t *name);
+typedef ngx_variable_value_t *(*ngx_keyval_get_index_variable)(void *data, ngx_uint_t index);
 
 char *ngx_keyval_conf_set_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf, ngx_keyval_conf_t *config, void *tag);
 #if (NGX_HAVE_KEYVAL_ZONE_REDIS)
 char *ngx_keyval_conf_set_zone_redis(ngx_conf_t *cf, ngx_command_t *cmd, void *conf, ngx_keyval_conf_t *config, void *tag);
 #endif
 char *ngx_keyval_conf_set_variable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf, ngx_keyval_conf_t *config, void *tag, ngx_keyval_variable_t **var, ngx_keyval_get_variable_index get_variable_index);
+ngx_int_t ngx_keyval_variable_get_key(ngx_connection_t *connection, ngx_keyval_variable_t *var, ngx_str_t *key, ngx_keyval_get_index_variable get_index_variable, void *data);
 
 void *ngx_keyval_create_main_conf(ngx_conf_t *cf);
 

--- a/src/ngx_keyval.h
+++ b/src/ngx_keyval.h
@@ -13,6 +13,7 @@ typedef enum {
 } ngx_keyval_zone_type_t;
 
 typedef struct {
+  ngx_array_t *indexes;
   ngx_array_t *variables;
   ngx_array_t *zones;
 } ngx_keyval_conf_t;
@@ -50,8 +51,7 @@ typedef struct {
 } ngx_keyval_zone_t;
 
 typedef struct {
-  ngx_int_t key_indexes[15];
-  ngx_int_t num_indexes;
+  ngx_array_t *indexes;
   ngx_str_t key_string;
   ngx_str_t variable;
   ngx_keyval_zone_t *zone;

--- a/src/ngx_keyval.h
+++ b/src/ngx_keyval.h
@@ -50,7 +50,8 @@ typedef struct {
 } ngx_keyval_zone_t;
 
 typedef struct {
-  ngx_int_t key_index;
+  ngx_int_t key_indexes[15];
+  ngx_int_t num_indexes;
   ngx_str_t key_string;
   ngx_str_t variable;
   ngx_keyval_zone_t *zone;

--- a/src/ngx_stream_keyval_module.c
+++ b/src/ngx_stream_keyval_module.c
@@ -143,15 +143,15 @@ ngx_stream_keyval_variable_get_key(ngx_stream_session_t *s,
     }
 
     for (ngx_int_t i = 0 ; i < var->num_indexes ; i++) {
-	    v[i] = ngx_stream_get_indexed_variable(s, var->key_indexes[i]);
+      v[i] = ngx_stream_get_indexed_variable(s, var->key_indexes[i]);
 
-	    if (v[i] == NULL || v[i]-> not_found) {
-		    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
-				    "keyval: variable specified was not provided");
-		    return NGX_ERROR;
-	    }
+      if (v[i] == NULL || v[i]-> not_found) {
+        ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+            "keyval: variable specified was not provided");
+        return NGX_ERROR;
+      }
 
-	    size_string += v[i]->len;
+      size_string += v[i]->len;
     }
 
     key->data = (u_char *) ngx_pnalloc(s->connection->pool, size_string + (string_var.len - var->num_indexes) + 1);
@@ -167,23 +167,23 @@ ngx_stream_keyval_variable_get_key(ngx_stream_session_t *s,
     u_char *last_space_available = key->data;
 
     for ( ; *(string_var.data) != '\0' ; string_var.data++) {
-	    if (*(string_var.data) == '$') {
-		    last_space_available = ngx_cpystrn(last_space_available, v[current_index]->data, v[current_index]->len + 1);
-		    key->len += v[current_index++]->len;
-	    }
+      if (*(string_var.data) == '$') {
+        last_space_available = ngx_cpystrn(last_space_available, v[current_index]->data, v[current_index]->len + 1);
+        key->len += v[current_index++]->len;
+      }
 
-	    else {
-		    *last_space_available = *(string_var.data);
-		    last_space_available += sizeof(u_char);
-		    key->len++;
-	    }
+      else {
+        *last_space_available = *(string_var.data);
+        last_space_available += sizeof(u_char);
+        key->len++;
+      }
     }
 
     *last_space_available = '\0';
   }
 
   else
-	  *key = var->key_string;
+    *key = var->key_string;
 
   return NGX_OK;
 }

--- a/src/ngx_stream_keyval_module.c
+++ b/src/ngx_stream_keyval_module.c
@@ -129,20 +129,17 @@ ngx_stream_keyval_variable_get_key(ngx_stream_session_t *s,
 
   /* The same idea as in the ngx_http_keyval_variable_get_key function */
 
-  if (var->num_indexes != 0)
-  {
+  if (var->num_indexes != 0) {
     ngx_stream_variable_value_t *v[var->num_indexes];
     ngx_int_t current_index = 0;
     ngx_str_t string_var = var->key_string;
     ngx_uint_t size_string = 0;
     ngx_log_t log;
 
-    for (ngx_int_t i = 0 ; i < var->num_indexes ; i++)
-    {
+    for (ngx_int_t i = 0 ; i < var->num_indexes ; i++) {
 	    v[i] = ngx_stream_get_indexed_variable(s, var->key_indexes[i]);
 
-	    if (v[i] == NULL || v[i]-> not_found)
-	    {
+	    if (v[i] == NULL || v[i]-> not_found) {
 		    ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
 				    "keyval: variable specified was not provided");
 		    return NGX_ERROR;
@@ -152,20 +149,24 @@ ngx_stream_keyval_variable_get_key(ngx_stream_session_t *s,
     }
 
     key->data = (u_char *) ngx_alloc(size_string + (string_var.len - var->num_indexes) + 1, &log);
+
+    if (key->data == NULL) {
+      ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+          "keyval: error allocating memory for key string");
+      return NGX_ERROR;
+    }
+
     key->len = 0;
 
     u_char *last_space_available = key->data;
 
-    for ( ; *(string_var.data) != '\0' ; string_var.data++)
-    {
-	    if (*(string_var.data) == '$')
-	    {
+    for ( ; *(string_var.data) != '\0' ; string_var.data++) {
+	    if (*(string_var.data) == '$') {
 		    last_space_available = ngx_cpystrn(last_space_available, v[current_index]->data, v[current_index]->len + 1);
 		    key->len += v[current_index++]->len;
 	    }
 
-	    else
-	    {
+	    else {
 		    *last_space_available = *(string_var.data);
 		    last_space_available += sizeof(u_char);
 		    key->len++;

--- a/t/keyval_multivar.t
+++ b/t/keyval_multivar.t
@@ -1,0 +1,186 @@
+use Test::Nginx::Socket 'no_plan';
+
+no_root_location();
+no_shuffle();
+
+run_tests();
+
+__DATA__
+
+=== Same host but different UA
+--- http_config
+keyval_zone zone=test:1M;
+keyval $remote_addr:$http_user_agent $keyval_data zone=test;
+--- config
+location = /get {
+  return 200 "get($http_user_agent): $keyval_data\n";
+}
+location = /set {
+  set $keyval_data "test $http_user_agent";
+  return 200 "$keyval_data\n";
+}
+--- request eval
+[
+    "GET /get",
+    "GET /get",
+    "GET /set",
+    "GET /set",
+    "GET /get",
+    "GET /get"
+]
+--- more_headers eval
+[
+    "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+    "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+    "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
+]
+--- response_body eval
+[
+    "get(Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0): \n",
+    "get(Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36): \n",
+    "test Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0\n",
+    "test Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36\n",
+    "get(Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0): test Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0\n",
+    "get(Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36): test Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36\n"
+]
+
+=== Two vars with different UAs
+--- http_config
+keyval_zone zone=test:5M;
+keyval "$remote_addr:$http_user_agent" $keyval_data1 zone=test;
+keyval "$remote_addr:$http_user_agent" $keyval_data2 zone=test;
+--- config
+location = /get {
+  return 200 "get($http_user_agent): $keyval_data1 $keyval_data2\n";
+}
+location = /set1 {
+  set $keyval_data1 "test1 $http_user_agent";
+  return 200 "$keyval_data1\n";
+}
+location = /set2 {
+  set $keyval_data2 "test2 $http_user_agent";
+  return 200 "$keyval_data2\n";
+}
+--- request eval
+[
+    "GET /get",
+    "GET /get",
+    "GET /set1",
+    "GET /set1",
+    "GET /set2",
+    "GET /set2",
+    "GET /get",
+    "GET /get"
+]
+--- more_headers eval
+[
+    "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+    "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+    "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+    "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
+]
+--- response_body eval
+[
+    "get(Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0):  \n",
+    "get(Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36):  \n",
+    "test1 Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0\n",
+    "test1 Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36\n",
+    "test2 Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0\n",
+    "test2 Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36\n",
+    "get(Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0): test2 Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0 test2 Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0\n",
+    "get(Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36): test2 Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 test2 Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36\n"
+]
+
+=== Same host but different UA and other chars in string
+--- http_config
+keyval_zone zone=test:1M;
+keyval "$remote_addr $http_user_agent random string random number 123456 test" $keyval_data zone=test;
+--- config
+location = /get {
+  return 200 "get($http_user_agent): $keyval_data\n";
+}
+location = /set {
+  set $keyval_data "test $http_user_agent";
+  return 200 "$keyval_data\n";
+}
+--- request eval
+[
+    "GET /get",
+    "GET /get",
+    "GET /set",
+    "GET /set",
+    "GET /get",
+    "GET /get"
+]
+--- more_headers eval
+[
+    "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+    "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+    "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
+]
+--- response_body eval
+[
+    "get(Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0): \n",
+    "get(Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36): \n",
+    "test Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0\n",
+    "test Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36\n",
+    "get(Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0): test Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0\n",
+    "get(Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36): test Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36\n"
+]
+
+=== Variables that exist and one that doesn't
+--- http_config
+keyval_zone zone=test:1M;
+keyval "$remote_addr $http_user_agent random string random number 123456 $hosst $request" $keyval_data zone=test;
+--- config
+--- must_die
+
+=== Pure text is still functional
+--- http_config
+keyval_zone zone=test:1M;
+keyval "text1 text2" $keyval_data zone=test;
+--- config
+location = /get {
+  return 200 "get($http_user_agent): $keyval_data\n";
+}
+location = /set {
+  set $keyval_data "test $http_user_agent";
+  return 200 "$keyval_data\n";
+}
+--- request eval
+[
+    "GET /get",
+    "GET /get",
+    "GET /set",
+    "GET /set",
+    "GET /get",
+    "GET /get"
+]
+--- more_headers eval
+[
+    "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+    "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+    "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
+]
+--- response_body eval
+[
+    "get(Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0): \n",
+    "get(Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36): \n",
+    "test Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0\n",
+    "test Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36\n",
+    "get(Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0): test Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36\n",
+    "get(Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36): test Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36\n"
+]


### PR DESCRIPTION
With this modification, we can use more than one variable in the key for the keyval command.

**Example 1**: 
- `keyval '$remote_addr:$http_user_agent' $var zone=$zone`
<br>

**Example 2**: 
- `keyval "$remote_addr     test_text $another_var another test \"$http_user_agent\" $host " $var zone=$zone`

The idea is very basic. We make a string mask (intermediate string). Where there's a variable, put a $ and take the variable name to get its index. Other chars are just copied.
During running time, all the '$' in string mask are replaced by the value of the desirable variable present in the request. The variable that store the index for the only variable we could have before has been changed for a array with size 15, which is the max variables allowed in the keyval key-string.

All code changed is commented. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced key-value storage module to support variable replacement in strings based on indexed variables, allowing for dynamic content customization.
	- Improved handling and logging of errors during variable substitution, ensuring more reliable operation.
	- Updated variable extraction function to handle up to 15 variables, optimizing the processing of configurations.
	- Introduced dynamic key construction based on multiple indexes for variable values, enhancing flexibility in key generation.
	- Added examples in README demonstrating variable and text mix usage in keyval_zone configuration.
- **Tests**
	- Added tests for new key-value storage capabilities with multiple variables, ensuring robustness and correctness of the feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->