### PR TITLE
 feat: implements timeout for keyval

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,16 @@ The database is stored in shared memory or Redis as specified
 by the zone parameter.
 
 ```
-Syntax: keyval_zone zone=name:size;
+Syntax: keyval_zone zone=name:size [ttl=time];
 Default: -
 Context: http
 ```
 
 Sets the `name` and `size` of the shared memory zone that
 keeps the key-value database.
+
+The optional `ttl` parameter sets the time to live
+which key-value pairs are removed (default value is `0` seconds).
 
 ```
 Syntax: keyval_zone_redis zone=name [hostname=name] [port=number] [database=number] [connect_timeout=time] [ttl=time];
@@ -145,13 +148,15 @@ The database is stored in shared memory or Redis as specified
 by the zone parameter.
 
 ```
-Syntax: keyval_zone zone=name:size;
+Syntax: keyval_zone zone=name:size [ttl=time];
 Default: -
 Context: http
 ```
 
 Sets the `name` and `size` of the shared memory zone that
 keeps the key-value database.
+
+The optional `ttl` parameter sets the time to live which key-value pairs are removed (default value is 0 seconds).
 
 ```
 Syntax: keyval_zone_redis zone=name [hostname=name] [port=number] [database=number] [connect_timeout=time] [ttl=time];
@@ -187,4 +192,4 @@ Example
 TODO
 ----
 
-- [ ] Support for `[state=file]`, `[timeout=time]` in `keyval_zone` directive
+- [ ] Support for `[state=file]` in `keyval_zone` directive

--- a/src/ngx_http_keyval_module.c
+++ b/src/ngx_http_keyval_module.c
@@ -18,7 +18,7 @@ static ngx_command_t ngx_http_keyval_commands[] = {
     0,
     NULL },
   { ngx_string("keyval_zone"),
-    NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+    NGX_HTTP_MAIN_CONF|NGX_CONF_1MORE,
     ngx_http_keyval_conf_set_zone,
     0,
     0,

--- a/src/ngx_keyval.c
+++ b/src/ngx_keyval.c
@@ -580,6 +580,7 @@ ngx_keyval_delete_timeout_node_shm(ngx_event_t *node_status)
   if (arg->ctx->shpool != NULL && arg->node != NULL) {
     ngx_rbtree_delete(&arg->ctx->sh->rbtree, arg->node);
     ngx_slab_free(arg->ctx->shpool, arg->node);
+    ngx_slab_free(arg->ctx->shpool, arg);
   }
 }
 

--- a/src/ngx_keyval.c
+++ b/src/ngx_keyval.c
@@ -1,3 +1,4 @@
+#include <ngx_event.h>
 #include "ngx_keyval.h"
 
 static void
@@ -266,6 +267,27 @@ ngx_keyval_conf_set_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
 
   shm_zone->init = ngx_keyval_init_zone;
   shm_zone->data = ctx;
+
+  if (cf->args->nelts >= 2) {
+    if (ngx_strncmp(value[2].data, "ttl=", 4) == 0 && value[2].len > 4) {
+      ngx_str_t s;
+
+      s.len = value[2].len - 4;
+      s.data = value[2].data + 4;
+
+      ctx->ttl = ngx_parse_time(&s, 1);
+      if (ctx->ttl == (time_t) NGX_ERROR) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                          "\"%V\" invalid ttl \"%V\"",
+                          &cmd->name, &value[2]);
+        ctx->ttl = 0;
+        return NGX_CONF_ERROR;
+      }
+    }
+  }
+
+  else
+    ctx->ttl = 0;
 
   return NGX_CONF_OK;
 }
@@ -550,6 +572,17 @@ ngx_keyval_shm_get_data(ngx_keyval_shm_ctx_t *ctx, ngx_shm_zone_t *shm,
   return NGX_OK;
 }
 
+static void
+ngx_keyval_delete_timeout_node_shm(ngx_event_t *node_status)
+{
+  ngx_keyval_node_timeout_t *arg = (ngx_keyval_node_timeout_t *) node_status->data;
+
+  if (arg->ctx->shpool != NULL && arg->node != NULL) {
+    ngx_rbtree_delete(&arg->ctx->sh->rbtree, arg->node);
+    ngx_slab_free(arg->ctx->shpool, arg->node);
+  }
+}
+
 ngx_int_t
 ngx_keyval_shm_set_data(ngx_keyval_shm_ctx_t *ctx, ngx_shm_zone_t *shm,
                         ngx_str_t *key, ngx_str_t *val, ngx_log_t *log)
@@ -596,6 +629,37 @@ ngx_keyval_shm_set_data(ngx_keyval_shm_ctx_t *ctx, ngx_shm_zone_t *shm,
     ngx_rbtree_insert(&ctx->sh->rbtree, node);
 
     rc = NGX_OK;
+
+    if (ctx->ttl) {
+      ngx_event_t *timeout_node_event = ngx_slab_alloc_locked(ctx->shpool, sizeof(ngx_event_t));
+
+      if (timeout_node_event == NULL) {
+        ngx_log_error(NGX_LOG_ERR, log, 0,
+                      "keyval: failed to allocate timeout event");
+        rc = NGX_ERROR;
+      }
+
+      else {
+        ngx_keyval_node_timeout_t *timeout_node = ngx_slab_alloc_locked(ctx->shpool, sizeof(ngx_keyval_node_timeout_t));
+
+        if (timeout_node == NULL) {
+          ngx_log_error(NGX_LOG_ERR, log, 0,
+                        "keyval:failed to allocate timeout node");
+          rc = NGX_ERROR;
+          ngx_slab_free_locked(ctx->shpool, timeout_node_event);
+        }
+
+        else {
+          timeout_node->node = node;
+          timeout_node->ctx = ctx;
+
+          timeout_node_event->data = (void *) timeout_node;
+          timeout_node_event->handler = ngx_keyval_delete_timeout_node_shm;
+          timeout_node_event->log = shm->shm.log;
+          ngx_add_timer(timeout_node_event, ctx->ttl * 1000);
+        }
+      }
+    }
   }
 
   ngx_shmtx_unlock(&ctx->shpool->mutex);

--- a/src/ngx_keyval.c
+++ b/src/ngx_keyval.c
@@ -278,16 +278,15 @@ ngx_keyval_conf_set_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
       ctx->ttl = ngx_parse_time(&s, 1);
       if (ctx->ttl == (time_t) NGX_ERROR) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                          "\"%V\" invalid ttl \"%V\"",
-                          &cmd->name, &value[2]);
+                           "\"%V\" invalid ttl \"%V\"",
+                           &cmd->name, &value[2]);
         ctx->ttl = 0;
         return NGX_CONF_ERROR;
       }
     }
-  }
-
-  else
+  } else {
     ctx->ttl = 0;
+  }
 
   return NGX_CONF_OK;
 }
@@ -575,7 +574,8 @@ ngx_keyval_shm_get_data(ngx_keyval_shm_ctx_t *ctx, ngx_shm_zone_t *shm,
 static void
 ngx_keyval_delete_timeout_node_shm(ngx_event_t *node_status)
 {
-  ngx_keyval_node_timeout_t *arg = (ngx_keyval_node_timeout_t *) node_status->data;
+  ngx_keyval_node_timeout_t *arg
+    = (ngx_keyval_node_timeout_t *) node_status->data;
 
   if (arg->ctx->shpool != NULL && arg->node != NULL) {
     ngx_rbtree_delete(&arg->ctx->sh->rbtree, arg->node);
@@ -632,25 +632,24 @@ ngx_keyval_shm_set_data(ngx_keyval_shm_ctx_t *ctx, ngx_shm_zone_t *shm,
     rc = NGX_OK;
 
     if (ctx->ttl) {
-      ngx_event_t *timeout_node_event = ngx_slab_alloc_locked(ctx->shpool, sizeof(ngx_event_t));
+      ngx_event_t *timeout_node_event
+        = ngx_slab_alloc_locked(ctx->shpool, sizeof(ngx_event_t));
 
       if (timeout_node_event == NULL) {
         ngx_log_error(NGX_LOG_ERR, log, 0,
                       "keyval: failed to allocate timeout event");
         rc = NGX_ERROR;
-      }
-
-      else {
-        ngx_keyval_node_timeout_t *timeout_node = ngx_slab_alloc_locked(ctx->shpool, sizeof(ngx_keyval_node_timeout_t));
+      } else {
+        ngx_keyval_node_timeout_t *timeout_node
+          = ngx_slab_alloc_locked(ctx->shpool,
+                                  sizeof(ngx_keyval_node_timeout_t));
 
         if (timeout_node == NULL) {
           ngx_log_error(NGX_LOG_ERR, log, 0,
-                        "keyval:failed to allocate timeout node");
+                        "keyval: failed to allocate timeout node");
           rc = NGX_ERROR;
           ngx_slab_free_locked(ctx->shpool, timeout_node_event);
-        }
-
-        else {
+        } else {
           timeout_node->node = node;
           timeout_node->ctx = ctx;
 

--- a/src/ngx_keyval.h
+++ b/src/ngx_keyval.h
@@ -32,7 +32,13 @@ typedef struct {
 typedef struct {
   ngx_keyval_sh_t *sh;
   ngx_slab_pool_t *shpool;
+  time_t ttl;
 } ngx_keyval_shm_ctx_t;
+
+typedef struct {
+  ngx_rbtree_node_t *node;
+  ngx_keyval_shm_ctx_t *ctx;
+} ngx_keyval_node_timeout_t;
 
 typedef struct {
   u_char *hostname;

--- a/src/ngx_stream_keyval_module.c
+++ b/src/ngx_stream_keyval_module.c
@@ -18,7 +18,7 @@ static ngx_command_t ngx_stream_keyval_commands[] = {
     0,
     NULL },
   { ngx_string("keyval_zone"),
-    NGX_STREAM_MAIN_CONF|NGX_CONF_TAKE1,
+    NGX_STREAM_MAIN_CONF|NGX_CONF_1MORE,
     ngx_stream_keyval_conf_set_zone,
     0,
     0,

--- a/t/keyval.t
+++ b/t/keyval.t
@@ -233,6 +233,198 @@ location = /set2 {
   "/get(key): 1:test1 2:test2\n"
 ]
 
+=== timeout (1s)
+--init
+system "sleep 1"
+--- http_config
+keyval_zone zone=timeout:5m ttl=1s;
+keyval $cookie_data_key $keyval_data zone=timeout;
+--- config
+location = /get {
+  return 200 "$request_uri($cookie_data_key): $keyval_data\n";
+}
+location = /set {
+  set $keyval_data "test1s";
+  return 200 "$request_uri($cookie_data_key): $keyval_data\n";
+}
+--- request eval
+[
+  "GET /get",
+  "GET /set",
+  "GET /get"
+]
+--- more_headers eval
+[
+  "Cookie: data_key=key",
+  "Cookie: data_key=key",
+  "Cookie: data_key=key"
+]
+--- response_body eval
+[
+  "/get(key): \n",
+  "/set(key): test1s\n",
+  "/get(key): test1s\n"
+]
+
+=== timeout (5s)
+--- wait: 5
+--- http_config
+keyval_zone zone=timeout:5m ttl=5s;
+keyval $cookie_data_key $keyval_data zone=timeout;
+--- config
+location = /get {
+  return 200 "$request_uri($cookie_data_key): $keyval_data\n";
+}
+location = /set {
+  set $keyval_data "test5s";
+  return 200 "$request_uri($cookie_data_key): $keyval_data\n";
+}
+--- request eval
+[
+  "GET /get",
+  "GET /set",
+  "GET /get"
+]
+--- more_headers eval
+[
+  "Cookie: data_key=key",
+  "Cookie: data_key=key",
+  "Cookie: data_key=key"
+]
+--- response_body eval
+[
+  "/get(key): \n",
+  "/set(key): test5s\n",
+  "/get(key): \n"
+]
+
+=== timeout (6s but with request within 5s)
+--- wait: 5
+--- http_config
+keyval_zone zone=timeout:5m ttl=6s;
+keyval $cookie_data_key $keyval_data zone=timeout;
+--- config
+location = /get {
+  return 200 "$request_uri($cookie_data_key): $keyval_data\n";
+}
+location = /set {
+  set $keyval_data "test5s";
+  return 200 "$request_uri($cookie_data_key): $keyval_data\n";
+}
+--- request eval
+[
+  "GET /get",
+  "GET /set",
+  "GET /get"
+]
+--- more_headers eval
+[
+  "Cookie: data_key=key",
+  "Cookie: data_key=key",
+  "Cookie: data_key=key"
+]
+--- response_body eval
+[
+  "/get(key): \n",
+  "/set(key): test5s\n",
+  "/get(key): test5s\n"
+]
+
+
+=== timeout (5s but with request within 5.1s)
+--- wait: 5.1
+--- http_config
+keyval_zone zone=timeout:5m ttl=5s;
+keyval $cookie_data_key $keyval_data zone=timeout;
+--- config
+location = /get {
+  return 200 "$request_uri($cookie_data_key): $keyval_data\n";
+}
+location = /set {
+  set $keyval_data "test5s";
+  return 200 "$request_uri($cookie_data_key): $keyval_data\n";
+}
+--- request eval
+[
+  "GET /get",
+  "GET /set",
+  "GET /get"
+]
+--- more_headers eval
+[
+  "Cookie: data_key=key",
+  "Cookie: data_key=key",
+  "Cookie: data_key=key"
+]
+--- response_body eval
+[
+  "/get(key): \n",
+  "/set(key): test5s\n",
+  "/get(key): \n"
+]
+
+=== timeout (1m)
+--- http_config
+keyval_zone zone=timeout:5m ttl=1m;
+keyval $cookie_data_key $keyval_data zone=timeout;
+--- config
+location = /get {
+  return 200 "$request_uri($cookie_data_key): $keyval_data\n";
+}
+location = /set {
+  set $keyval_data "test1m";
+  return 200 "$request_uri($cookie_data_key): $keyval_data\n";
+}
+--- request eval
+[
+  "GET /get",
+  "GET /set",
+  "GET /get"
+]
+--- more_headers eval
+[
+  "Cookie: data_key=key",
+  "Cookie: data_key=key",
+  "Cookie: data_key=key"
+]
+--- response_body eval
+[
+  "/get(key): \n",
+  "/set(key): test1m\n",
+  "/get(key): test1m\n"
+]
+
+=== timeout (1h)
+--- http_config
+keyval_zone zone=timeout:5m ttl=1h;
+keyval $cookie_data_key $keyval_data zone=timeout;
+--- config
+location = /get {
+  return 200 "$request_uri($cookie_data_key): $keyval_data\n";
+}
+location = /set {
+  set $keyval_data "test1h";
+  return 200 "$request_uri($cookie_data_key): $keyval_data\n";
+}
+--- request eval
+[
+  "GET /get",
+  "GET /set",
+  "GET /get"
+]
+--- more_headers eval
+[
+  "Cookie: data_key=key",
+  "Cookie: data_key=key",
+  "Cookie: data_key=key"
+]
+--- response_body eval
+[
+  "/get(key): \n",
+  "/set(key): test1h\n",
+  "/get(key): test1h\n"
+]
+
 === conf not found keyval_zone
 --- http_config
 keyval $cookie_data_key $keyval_data zone=test;
@@ -250,5 +442,12 @@ keyval $cookie_data_key $keyval_data;
 --- http_config
 keyval_zone zone=test:1M;
 keyval $cookie_data_key $keyval_data zone=test1;
+--- config
+--- must_die
+
+=== conf invalid ttl
+--- http_config
+keyval_zone zone=test:1M ttl=e5s;
+keyval $cookie_data_key $keyval_data zone=test;
 --- config
 --- must_die

--- a/t/stream.t
+++ b/t/stream.t
@@ -399,6 +399,282 @@ location = /get2 {
   "/get1: 127.0.0.1:8181\n",
 ]
 
+=== timeout (1s)
+--- skip_eval
+1: $ENV{"TEST_NGINX_LOAD_MODULES"} !~ /ngx_stream_keyval_module/
+--- wait: 0.9
+--- post_main_config
+stream {
+  keyval_zone zone=stream:5m ttl=1s;
+  keyval "stream_timeout" $keyval_host zone=stream;
+  upstream test1 {
+    server 127.0.0.1:8181;
+  }
+  server {
+    listen 8080;
+    proxy_pass $keyval_host;
+  }
+  server {
+    listen 8081;
+    proxy_pass test1;
+    set $keyval_host "test1";
+  }
+}
+--- http_config
+server {
+  listen 8181;
+  location / {
+    return 200 "$request_uri: $server_addr:$server_port\n";
+  }
+}
+--- config
+location = /get {
+  proxy_pass http://127.0.0.1:8080;
+}
+location = /set {
+  proxy_pass http://127.0.0.1:8081;
+}
+--- request eval
+[
+  "GET /get",
+  "GET /set",
+  "GET /get",
+]
+--- response_body_like eval
+[
+  "^.*\$",
+  "^/set: 127\.0\.0\.1:8181\$",
+  "^/get: 127\.0\.0\.1:8181\$",
+]
+--- error_code eval
+[
+  502,
+  200,
+  200,
+]
+
+=== timeout (6s but with request within 5s)
+--- skip_eval
+1: $ENV{"TEST_NGINX_LOAD_MODULES"} !~ /ngx_stream_keyval_module/
+--- wait: 5
+--- post_main_config
+stream {
+  keyval_zone zone=stream:5m ttl=6s;
+  keyval "stream_timeout" $keyval_host zone=stream;
+  upstream test1 {
+    server 127.0.0.1:8181;
+  }
+  server {
+    listen 8080;
+    proxy_pass $keyval_host;
+  }
+  server {
+    listen 8081;
+    proxy_pass test1;
+    set $keyval_host "test1";
+  }
+}
+--- http_config
+server {
+  listen 8181;
+  location / {
+    return 200 "$request_uri: $server_addr:$server_port\n";
+  }
+}
+--- config
+location = /get {
+  proxy_pass http://127.0.0.1:8080;
+}
+location = /set {
+  proxy_pass http://127.0.0.1:8081;
+}
+--- request eval
+[
+  "GET /get",
+  "GET /set",
+  "GET /get",
+]
+--- response_body_like eval
+[
+  "^.*\$",
+  "^/set: 127\.0\.0\.1:8181\$",
+  "^/get: 127\.0\.0\.1:8181\$",
+]
+--- error_code eval
+[
+  502,
+  200,
+  200,
+]
+
+=== timeout (5s but with request within 5.1s)
+--- skip_eval
+1: $ENV{"TEST_NGINX_LOAD_MODULES"} !~ /ngx_stream_keyval_module/
+--- wait: 5.1
+--- post_main_config
+stream {
+  keyval_zone zone=stream:5m ttl=5s;
+  keyval "stream_timeout" $keyval_host zone=stream;
+  upstream test1 {
+    server 127.0.0.1:8181;
+  }
+  server {
+    listen 8080;
+    proxy_pass $keyval_host;
+  }
+  server {
+    listen 8081;
+    proxy_pass test1;
+    set $keyval_host "test1";
+  }
+}
+--- http_config
+server {
+  listen 8181;
+  location / {
+    return 200 "$request_uri: $server_addr:$server_port\n";
+  }
+}
+--- config
+location = /get {
+  proxy_pass http://127.0.0.1:8080;
+}
+location = /set {
+  proxy_pass http://127.0.0.1:8081;
+}
+--- request eval
+[
+  "GET /get",
+  "GET /set",
+  "GET /get",
+]
+--- response_body_like eval
+[
+  "^.*\$",
+  "^/set: 127\.0\.0\.1:8181\$",
+  "^.*\$",
+]
+--- error_code eval
+[
+  502,
+  200,
+  502
+]
+
+=== timeout (1m)
+--- skip_eval
+1: $ENV{"TEST_NGINX_LOAD_MODULES"} !~ /ngx_stream_keyval_module/
+--- init
+system "sleep 1"
+--- post_main_config
+stream {
+  keyval_zone zone=stream:5m ttl=1m;
+  keyval "stream_timeout" $keyval_host zone=stream;
+  upstream test1 {
+    server 127.0.0.1:8181;
+  }
+  upstream test2 {
+    server 127.0.0.2:8181;
+  }
+  server {
+    listen 8080;
+    proxy_pass $keyval_host;
+  }
+  server {
+    listen 8081;
+    proxy_pass test2;
+    set $keyval_host "test2";
+  }
+}
+--- http_config
+server {
+  listen 8181;
+  location / {
+    return 200 "$request_uri: $server_addr:$server_port\n";
+  }
+}
+--- config
+location = /get {
+  proxy_pass http://127.0.0.1:8080;
+}
+location = /set {
+  proxy_pass http://127.0.0.2:8081;
+}
+--- request eval
+[
+  "GET /get",
+  "GET /set",
+  "GET /get",
+]
+--- response_body_like eval
+[
+  "^.*\$",
+  "^/set: 127\.0\.0\.2:8181\$",
+  "^/get: 127\.0\.0\.2:8181\$",
+]
+--- error_code eval
+[
+  502,
+  200,
+  200,
+]
+
+=== timeout (1h)
+--- skip_eval
+1: $ENV{"TEST_NGINX_LOAD_MODULES"} !~ /ngx_stream_keyval_module/
+--- post_main_config
+stream {
+  keyval_zone zone=stream:5m ttl=1h;
+  keyval "stream_timeout" $keyval_host zone=stream;
+  upstream test2 {
+    server 127.0.0.2:8181;
+  }
+  upstream test3 {
+    server 127.0.0.3:8181;
+  }
+  server {
+    listen 8080;
+    proxy_pass $keyval_host;
+  }
+  server {
+    listen 8081;
+    proxy_pass test3;
+    set $keyval_host "test3";
+  }
+}
+--- http_config
+server {
+  listen 8181;
+  location / {
+    return 200 "$request_uri: $server_addr:$server_port\n";
+  }
+}
+--- config
+location = /get {
+  proxy_pass http://127.0.0.1:8080;
+}
+location = /set {
+  proxy_pass http://127.0.0.3:8081;
+}
+--- request eval
+[
+  "GET /get",
+  "GET /set",
+  "GET /get",
+]
+--- response_body_like eval
+[
+  "^.*\$",
+  "^/set: 127\.0\.0\.3:8181\$",
+  "^/get: 127\.0\.0\.3:8181\$",
+]
+--- error_code eval
+[
+  502,
+  200,
+  200,
+]
+
 === conf not found keyval_zone
 --- skip_eval
 1: $ENV{"TEST_NGINX_LOAD_MODULES"} !~ /ngx_stream_keyval_module/
@@ -427,6 +703,17 @@ stream {
 stream {
   keyval_zone zone=stream:1M;
   keyval "stream_conf_invalid_zone_parameter" $keyval_host zone=invalid;
+}
+--- config
+--- must_die
+
+=== conf invalid ttl
+--- skip_eval
+1: $ENV{"TEST_NGINX_LOAD_MODULES"} !~ /ngx_stream_keyval_module/
+--- post_main_config
+stream {
+  keyval_zone zone=stream:1M ttl=e20s;
+  keyval $cookie_data_key $keyval_data zone=test;
 }
 --- config
 --- must_die


### PR DESCRIPTION
Using the timer for events implemented by nginx, we can use ttl in keyval zones. This creates a struct for store the pointer for the node, which should be deleted after an amount of time specified on the configuration, and the pointer for the context. The ttl belongs to this context too. When the node is created, the function `ngx_keyval_shm_set_data` creates an event and adds a timer for this event. The handler (`ngx_keyval_delete_timeout_node_shm`) deletes the node. So, the next time when key is checked, there won't be a node with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added inclusion of `ngx_event.h` for improved event handling.
    - Implemented TTL configuration for automatic expiration of key-value pairs.
    - Introduced parsing and handling of variables in strings for dynamic content.
    - Enhanced shared memory functionality to manage timeout nodes effectively.

- **Improvements**
    - Optimized memory management and error handling in key-value string construction.
    - Extended key-value storage to support multiple indexes for complex data scenarios.

- **Documentation**
    - Updated to include details on TTL configuration, variable handling, and memory management changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->