### PR TITLE
docs: add pre-built Ubuntu/Debian package installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,28 @@ This nginx module creates variables with values taken from key-value pairs.
 > This module is heavily inspired by the nginx original
 > [http_keyval_module](https://nginx.org/en/docs/http/ngx_http_keyval_module.html).
 
+Pre-built Packages (Ubuntu / Debian)
+------------------------------------
+
+Pre-built packages for this module are freely available from the GetPageSpeed repository:
+
+```bash
+# Install the repository keyring
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://extras.getpagespeed.com/deb-archive-keyring.gpg \
+  | sudo tee /etc/apt/keyrings/getpagespeed.gpg >/dev/null
+
+# Add the repository (Ubuntu example - replace 'ubuntu' and 'jammy' for your distro)
+echo "deb [signed-by=/etc/apt/keyrings/getpagespeed.gpg] https://extras.getpagespeed.com/ubuntu jammy main" \
+  | sudo tee /etc/apt/sources.list.d/getpagespeed-extras.list
+
+# Install nginx and the module
+sudo apt-get update
+sudo apt-get install nginx nginx-module-keyval
+```
+
+The module is automatically enabled after installation. Supported distributions include Debian 12/13 and Ubuntu 20.04/22.04/24.04 (both amd64 and arm64). See [the complete setup instructions](https://apt-nginx-extras.getpagespeed.com/apt-setup/).
+
 Dependency
 ----------
 


### PR DESCRIPTION
This PR adds installation instructions for pre-built Ubuntu/Debian packages from the GetPageSpeed repository.

The packages are available for:
- Ubuntu 20.04, 22.04, 24.04 (amd64 and arm64)
- Debian 12, 13 (amd64 and arm64)

This makes it easier for users to install the module without compiling from source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation guide for pre-built packages on Ubuntu and Debian systems, including repository setup instructions and list of supported distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->