### PR TITLE
ci: update nginx test versions to 1.29.8 mainline

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -186,7 +186,7 @@ jobs:
           - alpine
           - ubuntu
           - '1.28.3' # stable
-          - '1.29.7' # mainline
+          - '1.29.8' # mainline
         optional:
           - ''
           - 'redis'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure configuration to use Nginx version 1.29.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->