### PR TITLE
ci: bump nginx to stable to 1.30.2 and mainline to 1.31.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -185,8 +185,8 @@ jobs:
         nginx:
           - alpine
           - ubuntu
-          - '1.30.1' # stable
-          - '1.31.0' # mainline
+          - '1.30.2' # stable
+          - '1.31.1' # mainline
         optional:
           - ''
           - 'redis'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure to run against newer Nginx versions for improved compatibility verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->