### PR TITLE
Fix redis ctx zone mixup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [fdc4294](../../commit/fdc4294) - 2026-06-15
+
+### Fixed
+
+- Isolate Redis connection context per zone so that multiple `keyval_zone_redis` zones with different hostname/port/database accessed in the same request no longer reuse the first zone's connection
+
 ## [172ac41](../../commit/172ac41) - 2026-03-27
 
 ### Changed

--- a/src/ngx_keyval.h
+++ b/src/ngx_keyval.h
@@ -77,7 +77,8 @@ typedef struct {
 
 #if (NGX_HAVE_KEYVAL_ZONE_REDIS)
 typedef struct {
-    redisContext *redis;
+    ngx_keyval_zone_t *zone;
+    redisContext      *redis;
 } ngx_keyval_redis_ctx_t;
 #endif
 

--- a/src/ngx_keyval_store.c
+++ b/src/ngx_keyval_store.c
@@ -45,15 +45,19 @@ ngx_keyval_store_ops_t ngx_keyval_store_shm_ops = {
 #if (NGX_HAVE_KEYVAL_ZONE_REDIS)
 
 static ngx_keyval_redis_ctx_t *
-ngx_keyval_store_redis_get_ctx(ngx_pool_t *pool, ngx_log_t *log)
+ngx_keyval_store_redis_get_ctx(ngx_keyval_zone_t *zone, ngx_pool_t *pool,
+    ngx_log_t *log)
 {
     ngx_pool_cleanup_t *cln;
     ngx_keyval_redis_ctx_t *ctx;
 
-    /* find existing Redis ctx registered on this pool */
+    /* find existing Redis ctx for this zone registered on this pool */
     for (cln = pool->cleanup; cln; cln = cln->next) {
         if (cln->handler == ngx_keyval_redis_cleanup_ctx) {
-            return cln->data;
+            ctx = cln->data;
+            if (ctx->zone == zone) {
+                return ctx;
+            }
         }
     }
 
@@ -64,6 +68,7 @@ ngx_keyval_store_redis_get_ctx(ngx_pool_t *pool, ngx_log_t *log)
                       "keyval: failed to allocate redis context");
         return NULL;
     }
+    ctx->zone = zone;
 
     cln = ngx_pool_cleanup_add(pool, 0);
     if (cln == NULL) {
@@ -85,7 +90,7 @@ ngx_keyval_store_redis_get(ngx_keyval_zone_t *zone, ngx_str_t *key,
     ngx_keyval_redis_ctx_t *ctx;
     redisContext *context;
 
-    ctx = ngx_keyval_store_redis_get_ctx(pool, log);
+    ctx = ngx_keyval_store_redis_get_ctx(zone, pool, log);
     if (ctx == NULL) {
         return NGX_ERROR;
     }
@@ -106,7 +111,7 @@ ngx_keyval_store_redis_set(ngx_keyval_zone_t *zone, ngx_str_t *key,
     ngx_keyval_redis_ctx_t *ctx;
     redisContext *context;
 
-    ctx = ngx_keyval_store_redis_get_ctx(pool, log);
+    ctx = ngx_keyval_store_redis_get_ctx(zone, pool, log);
     if (ctx == NULL) {
         return;
     }

--- a/t/03_keyval_zone_redis.t
+++ b/t/03_keyval_zone_redis.t
@@ -246,6 +246,45 @@ location = /set2 {
   "/get(key): 1:test1 2:test2\n"
 ]
 
+=== multiple zone (different database)
+--- init
+system "redis-cli flushall"
+--- http_config
+keyval_zone_redis zone=mzdb0 database=0 ttl=30s;
+keyval_zone_redis zone=mzdb1 database=1 ttl=30s;
+keyval $cookie_data_key $keyval_data0 zone=mzdb0;
+keyval $cookie_data_key $keyval_data1 zone=mzdb1;
+--- config
+location = /set {
+  set $keyval_data0 "db0";
+  set $keyval_data1 "db1";
+  return 200 "set\n";
+}
+location = /get0 {
+  return 200 "$keyval_data0\n";
+}
+location = /get1 {
+  return 200 "$keyval_data1\n";
+}
+--- request eval
+[
+  "GET /set",
+  "GET /get0",
+  "GET /get1"
+]
+--- more_headers eval
+[
+  "Cookie: data_key=key",
+  "Cookie: data_key=key",
+  "Cookie: data_key=key"
+]
+--- response_body eval
+[
+  "set\n",
+  "db0\n",
+  "db1\n"
+]
+
 === keep set
 --- http_config
 keyval_zone_redis zone=keep ttl=300s;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Redis-backed key-value zones to properly maintain isolation when configured with different `database` values. Previously, zones could reuse the wrong Redis connection within the same request; now each zone keeps its own connection context association.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->