### PR TITLE
Fix key builder nul truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [5850601](../../commit/5850601) - 2026-06-15
+
+### Fixed
+
+- Use `ngx_cpymem` when building variable keys so that values containing NUL bytes (e.g. `$binary_remote_addr`) are copied in full, preventing uninitialized pool memory from leaking into stored/transmitted keys and breaking get/set lookups
+
 ## [fdc4294](../../commit/fdc4294) - 2026-06-15
 
 ### Fixed

--- a/src/ngx_keyval_variable.c
+++ b/src/ngx_keyval_variable.c
@@ -71,9 +71,9 @@ ngx_keyval_variable_get_key(ngx_pool_t *pool, ngx_connection_t *connection,
                                   "than indexes");
                     return NGX_ERROR;
                 }
-                last_space_available = ngx_cpystrn(last_space_available,
-                                                   v[current_index]->data,
-                                                   v[current_index]->len + 1);
+                last_space_available = ngx_cpymem(last_space_available,
+                                                  v[current_index]->data,
+                                                  v[current_index]->len);
                 key->len += v[current_index++]->len;
             } else {
                 *last_space_available = *p;

--- a/t/01_keyval_basic.t
+++ b/t/01_keyval_basic.t
@@ -456,6 +456,31 @@ location = /set {
   "/get(key): \n"
 ]
 
+=== binary key containing NUL bytes
+--- http_config
+keyval_zone zone=binkey:1M;
+keyval $binary_remote_addr $keyval_data zone=binkey;
+--- config
+location = /get {
+  return 200 "$request_uri: $keyval_data\n";
+}
+location = /set {
+  set $keyval_data "binval";
+  return 200 "$request_uri: $keyval_data\n";
+}
+--- request eval
+[
+  "GET /get",
+  "GET /set",
+  "GET /get"
+]
+--- response_body eval
+[
+  "/get: \n",
+  "/set: binval\n",
+  "/get: binval\n"
+]
+
 === conf not found keyval_zone
 --- http_config
 keyval $cookie_data_key $keyval_data zone=test;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed key-value get/set operations to properly process binary data containing NUL bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->