### PR TITLE
Feat redis command timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [b3a3223](../../commit/b3a3223) - 2026-06-15
+
+### Added
+
+- `command_timeout=` parameter for `keyval_zone_redis` (default `3s`) that bounds the send/receive of each Redis command (SELECT/GET/SET/SETEX) via `redisSetTimeout`. Previously only the connection timeout was configured, leaving command round-trips unbounded, so an unresponsive, extremely slow, or half-open Redis could block the nginx worker process and its entire event loop indefinitely, escalating into a worker-wide DoS
+
 ## [5850601](../../commit/5850601) - 2026-06-15
 
 ### Fixed

--- a/docs/DIRECTIVES.md
+++ b/docs/DIRECTIVES.md
@@ -95,7 +95,7 @@ keyval_zone zone=session:1m ttl=1h;   # Expires after 1 hour
 ### keyval_zone_redis
 
 ```
-Syntax:  keyval_zone_redis zone=name [hostname=name] [port=number] [database=number] [connect_timeout=time] [ttl=time];
+Syntax:  keyval_zone_redis zone=name [hostname=name] [port=number] [database=number] [connect_timeout=time] [command_timeout=time] [ttl=time];
 Default: --
 Context: http, stream
 ```
@@ -113,7 +113,16 @@ Defines the name and connection settings for a Redis zone that holds the key-val
 | `port=number` | No | `6379` | Redis server port number |
 | `database=number` | No | `0` | Redis database number |
 | `connect_timeout=time` | No | `3s` | Redis connection timeout |
+| `command_timeout=time` | No | `3s` | Redis command (send/receive) timeout |
 | `ttl=time` | No | `0` (no expiration) | Expiration time for key-value pairs |
+
+#### Timeout Behavior
+
+`connect_timeout` bounds the time to establish the TCP connection to Redis. `command_timeout` bounds the send/receive of each command (`SELECT`/`GET`/`SET`/`SETEX`) after the connection is established, and is applied as the socket send/receive timeout via `redisSetTimeout()`.
+
+Because this module uses the hiredis synchronous API, without `command_timeout` the worker process can block indefinitely against a Redis that is unresponsive, extremely slow, or behind a half-open network. When a timeout occurs, the Redis connection for that request enters an error state and is not reused. See [SECURITY.md](SECURITY.md) for details.
+
+`command_timeout` may not be set to `0` (since `0` disables the blocking bound and defeats the purpose of the parameter, it is rejected as a configuration error). The minimum unit is 1 second; a sub-second value such as `500ms` is rounded down to `0` and rejected as a configuration error.
 
 #### TTL Behavior
 
@@ -131,6 +140,7 @@ keyval_zone_redis zone=kv_remote
                   port=6380
                   database=1
                   connect_timeout=5s
+                  command_timeout=2s
                   ttl=1h;
 ```
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -31,6 +31,25 @@ When using the Redis backend, data is transmitted over the network.
   - TLS proxy feature in Redis 6 and later
 - If Redis AUTH (`requirepass`) is enabled, a proxy that handles authentication is also required, as this module does not send AUTH commands
 
+### Blocking I/O DoS Risk
+
+This module uses the hiredis synchronous API and sends/receives commands to
+Redis in a blocking manner during request processing. Against a Redis that is
+unresponsive, extremely slow, or behind a half-open network (TCP established
+but no packets returned), the nginx worker process can stall along with its
+entire event loop unless a bound is set. All other connections handled by that
+worker are dragged down with it, so a Redis-side failure can escalate into a
+service outage (DoS) for nginx as a whole.
+
+**Recommendations:**
+
+- Set both `connect_timeout` (connection establishment) and `command_timeout`
+  (command send/receive) according to your requirements. Both default to `3s`.
+- For unstable networks or remote Redis, set `command_timeout` as low as the
+  acceptable response-latency ceiling allows.
+- When a timeout occurs, the Redis connection for that request enters an error
+  state and is not reused (it is reconnected on the next request).
+
 ## Key Design Best Practices
 
 Improper key design can lead to security risks.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -113,7 +113,7 @@ invalid parameter "xxx"
 Check the spelling of the parameter. Valid parameters:
 
 - `keyval_zone`: `zone=name:size`, `ttl=time`, `timeout=time`
-- `keyval_zone_redis`: `zone=name`, `hostname=addr`, `port=num`, `database=num`, `connect_timeout=time`, `ttl=time`
+- `keyval_zone_redis`: `zone=name`, `hostname=addr`, `port=num`, `database=num`, `connect_timeout=time`, `command_timeout=time`, `ttl=time`
 
 ### zone not found
 

--- a/src/ngx_keyval.h
+++ b/src/ngx_keyval.h
@@ -47,6 +47,7 @@ typedef struct {
     ngx_int_t  db;
     time_t     ttl;
     time_t     connect_timeout;
+    time_t     command_timeout;
 } ngx_keyval_redis_conf_t;
 
 /* Forward declaration for store ops */

--- a/src/ngx_keyval_store_redis.c
+++ b/src/ngx_keyval_store_redis.c
@@ -55,6 +55,19 @@ ngx_keyval_redis_get_context(ngx_keyval_redis_ctx_t *ctx,
         return NULL;
     }
 
+    timeout.tv_sec = conf->command_timeout;
+    if (redisSetTimeout(ctx->redis, timeout) != REDIS_OK) {
+        ngx_log_error(NGX_LOG_ERR, log, 0,
+                      "keyval: failed to set redis command timeout: "
+                      "hostname=%s port=%d command_timeout=%ds: %s",
+                      (char *) conf->hostname, conf->port,
+                      conf->command_timeout,
+                      ctx->redis->errstr);
+        redisFree(ctx->redis);
+        ctx->redis = NULL;
+        return NULL;
+    }
+
     if (conf->db > 0) {
         redisReply *resp = NULL;
 

--- a/src/ngx_keyval_zone.c
+++ b/src/ngx_keyval_zone.c
@@ -246,6 +246,7 @@ ngx_keyval_conf_set_zone_redis(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
     zone->redis.db = 0;
     zone->redis.ttl = 0;
     zone->redis.connect_timeout = 3;
+    zone->redis.command_timeout = 3;
 
     for (i = 2; i < cf->args->nelts; i++) {
         if (ngx_strncmp(value[i].data, "hostname=",
@@ -313,6 +314,26 @@ ngx_keyval_conf_set_zone_redis(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
             if (zone->redis.connect_timeout == (time_t) NGX_ERROR) {
                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                    "\"%V\" invalid connect timeout \"%V\"",
+                                   &cmd->name, &value[i]);
+                return NGX_CONF_ERROR;
+            }
+            continue;
+        }
+
+        if (ngx_strncmp(value[i].data, "command_timeout=", 16) == 0
+            && value[i].len > 16)
+        {
+            ngx_str_t s;
+
+            s.len = value[i].len - 16;
+            s.data = value[i].data + 16;
+
+            zone->redis.command_timeout = ngx_parse_time(&s, 1);
+            if (zone->redis.command_timeout == (time_t) NGX_ERROR
+                || zone->redis.command_timeout == 0)
+            {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "\"%V\" invalid command timeout \"%V\"",
                                    &cmd->name, &value[i]);
                 return NGX_CONF_ERROR;
             }

--- a/t/03_keyval_zone_redis.t
+++ b/t/03_keyval_zone_redis.t
@@ -681,6 +681,37 @@ location = /set {
   "/get(key): test1h\n"
 ]
 
+=== command_timeout (1s)
+--- http_config
+keyval_zone_redis zone=cmdtimeout command_timeout=1s;
+keyval $cookie_data_key $keyval_data zone=cmdtimeout;
+--- config
+location = /get {
+  return 200 "$request_uri($cookie_data_key): $keyval_data\n";
+}
+location = /set {
+  set $keyval_data "testcmd";
+  return 200 "$request_uri($cookie_data_key): $keyval_data\n";
+}
+--- request eval
+[
+  "GET /get",
+  "GET /set",
+  "GET /get"
+]
+--- more_headers eval
+[
+  "Cookie: data_key=key",
+  "Cookie: data_key=key",
+  "Cookie: data_key=key"
+]
+--- response_body eval
+[
+  "/get(key): \n",
+  "/set(key): testcmd\n",
+  "/get(key): testcmd\n"
+]
+
 === conf not found keyval_zone_redis
 --- http_config
 keyval $cookie_data_key $keyval_data zone=invalid;
@@ -720,6 +751,27 @@ keyval $cookie_data_key $keyval_data zone=invalid;
 === conf redis invalid ttl
 --- http_config
 keyval_zone_redis zone=test ttl=abc;
+keyval $cookie_data_key $keyval_data zone=test;
+--- config
+--- must_die
+
+=== conf redis invalid command_timeout
+--- http_config
+keyval_zone_redis zone=test command_timeout=abc;
+keyval $cookie_data_key $keyval_data zone=test;
+--- config
+--- must_die
+
+=== conf redis zero command_timeout
+--- http_config
+keyval_zone_redis zone=test command_timeout=0;
+keyval $cookie_data_key $keyval_data zone=test;
+--- config
+--- must_die
+
+=== conf redis sub-second command_timeout
+--- http_config
+keyval_zone_redis zone=test command_timeout=500ms;
 keyval $cookie_data_key $keyval_data zone=test;
 --- config
 --- must_die


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `command_timeout` parameter to `keyval_zone_redis` directive (default: 3 seconds) to bound Redis command send/receive operations and prevent indefinite worker blocking during network timeouts.

* **Documentation**
  * Updated configuration syntax, security guidance, and troubleshooting resources with timeout recommendations and validation behavior.

* **Tests**
  * Added test coverage for `command_timeout` parameter validation and configuration constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->