### PR TITLE
ci: bump nginx to stable to 1.30.3 and mainline to 1.31.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -185,8 +185,8 @@ jobs:
         nginx:
           - alpine
           - ubuntu
-          - '1.30.2' # stable
-          - '1.31.1' # mainline
+          - '1.30.3' # stable
+          - '1.31.2' # mainline
         optional:
           - ''
           - 'redis'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure with newer Nginx versions to ensure tests run against current software releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->